### PR TITLE
update zelect.js

### DIFF
--- a/zelect.js
+++ b/zelect.js
@@ -64,6 +64,8 @@
       $list.on('click', 'li', function() { selectItem($(this).data('zelect-item')) })
       $zelect.mouseenter(function() { $zelect.addClass('hover') })
       $zelect.mouseleave(function() { $zelect.removeClass('hover') })
+      $zelect.attr("tabindex", $select.attr("tabindex"))
+      $zelect.blur(function() { if (!$zelect.hasClass('hover')) hide() })
       $search.blur(function() { if (!$zelect.hasClass('hover')) hide() })
 
       $selected.click(toggle)


### PR DESCRIPTION
Add support for focusable/blurrable zelects by inheriting tabindex attribute. Adds support for blur event in dropdowns that don't have an input box.
