### PR TITLE
Add triggerChange parameter to selectItem()

### DIFF
--- a/zelect.js
+++ b/zelect.js
@@ -79,11 +79,12 @@
         $select.trigger('ready')
       })
 
-      function selectItem(item) {
+      function selectItem(item, triggerChange) {
         renderContent($selected, opts.renderItem(item)).removeClass('placeholder')
         hide()
         if (item && item.value) $select.val(item.value)
-        $select.data('zelected', item).trigger('change', item)
+        if (triggerChange == null || triggerChange === true)
+          $select.data('zelected', item).trigger('change', item)
       }
 
       function refreshItem(item, identityCheckFn) {


### PR DESCRIPTION
Input box contents can be changed without triggering change event, ie. textbox.val("test"). Change event must be triggered manually, textbox.val("test").change(). 
Shouldn't "silent" value change be possible in zelect, too?
