### PR TITLE
zelect fails silently if <select> does not have parent

### DIFF
--- a/test.html
+++ b/test.html
@@ -52,6 +52,11 @@
       <option>Evil option &lt;script&gt;throw new Error('XSS from option label')&lt;/script&gt;</option>
       <option value="&lt;script&gt;throw new Error('XSS from option value')&lt;/script&gt;">Evil value</option>
     </select>
+    <select class="option-with-empty-string">
+      <option value="something">Has a value</option>
+      <option value="something-elese">Also has a value</option>
+      <option value="">Has empty string as value</option>
+    </select>
   </div>
 </body>
 </html>

--- a/test.js
+++ b/test.js
@@ -261,6 +261,15 @@ describe('zelect', function() {
       val('#select', 'second')
     })
 
+    it('allows empty string as an option value', function() {
+      setup('option-with-empty-string')
+      $('#select').zelect()
+      $('.zelected').click()
+      $('.dropdown li:last').click()
+      txt('.zelected', 'Has empty string as value')
+      val('#select', '')
+    })
+
     it('throttles search input', function(done) {
       setup('with-two-options-with-values')
       $('#select').zelect({

--- a/test.js
+++ b/test.js
@@ -300,6 +300,15 @@ describe('zelect', function() {
       defaultInitialState()
     })
 
+    it('throws an error if <select> does not have the required parent element', function() {
+      try {
+        $('<select>').zelect()
+      } catch (catched) {
+        var err = catched
+      }
+      eq(err && err.message, "jQuery.insertAfter cannot be done: <select> element must have a parent element")
+    })
+
     it('$(select).reset()', function() {
       setup('with-two-options')
       $('#select').zelect()

--- a/zelect.js
+++ b/zelect.js
@@ -70,6 +70,7 @@
 
       $selected.click(toggle)
 
+      if ($select.parent().length === 0) throw new Error('jQuery.insertAfter cannot be done: <select> element must have a parent element')
       $zelect.insertAfter($select)
         .append($selected)
         .append($dropdown.append($('<div>').addClass('zearch-container').append($search).append($noResults)).append($list))

--- a/zelect.js
+++ b/zelect.js
@@ -82,7 +82,7 @@
       function selectItem(item, triggerChange) {
         renderContent($selected, opts.renderItem(item)).removeClass('placeholder')
         hide()
-        if (item && item.value) $select.val(item.value)
+        if (item && item.value !== undefined) $select.val(item.value)
         $select.data('zelected', item)
         if (triggerChange == null || triggerChange === true) $select.trigger('change', item)
       }


### PR DESCRIPTION
If the <select> element does not (yet) have a parent, the zelect element fails to display and does not throw any error.

This patch makes zelect throw an error message if it's called on an element that does not have the required parent element.
