### PR TITLE
Enable focusing on zelect by tabbing

### DIFF
--- a/tabtest.html
+++ b/tabtest.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Tabbing test</title>
+  <script src="node_modules/jquery-browser/lib/jquery.js"></script>
+  <script src="zelect.js"></script>
+</head>
+<body>
+  <h2>With <code>tabindex</code></h2>
+  <p><input type="text" class="field1" tabindex="1" /></p>
+  <p><select class="field2" tabindex="2">
+    <option>First</option>
+    <option>Last</option>
+  </select></p>
+  <p><input type="text" class="field3" tabindex="3" /></p>
+  <h2>Without <code>tabindex</code></h2>
+  <p><input type="text" class="field1" /></p>
+  <p><select class="field2">
+    <option>First</option>
+    <option>Last</option>
+  </select></p>
+  <p><input type="text" class="field3" /></p>
+  <script>
+    $('select').zelect()
+  </script>
+</body>
+</html>

--- a/test.html
+++ b/test.html
@@ -57,6 +57,14 @@
       <option value="something-elese">Also has a value</option>
       <option value="">Has empty string as value</option>
     </select>
+    <div class="multiple-fields">
+      <p><input type="text" class="field1" /></p>
+      <p><select class="field2">
+        <option>First</option>
+        <option>Last</option>
+      </select></p>
+      <p><input type="text" class="field3" /></p>
+    </div>
   </div>
 </body>
 </html>

--- a/test.js
+++ b/test.js
@@ -472,6 +472,17 @@ describe('zelect', function() {
     })
   })
 
+  describe('Catching tab focus', function() {
+    beforeEach(function() {
+      setup('multiple-fields')
+      $('#select').find('.field2').zelect()
+    })
+    it('focusing on catcher element opens search', function() {
+      $('#select').find('.focuz').focus()
+      defaultOpenState()
+    })
+  })
+
   function ok(bool, msg) {
     assert.isTrue(bool, msg)
   }

--- a/zelect.js
+++ b/zelect.js
@@ -32,6 +32,7 @@
       var $zelect = $('<div>').addClass('zelect')
       var $selected = $('<div>').addClass('zelected')
       var $dropdown = $('<div>').addClass('dropdown').hide()
+      var $focusCatcher = $('<input>').addClass('focuz').css({ height: 0, width: 0, border: 'none', display: 'block', padding: 0 })
       var $noResults = $('<div>').addClass('no-results')
       var $search = $('<input>').addClass('zearch')
       var $list = $('<ol>')
@@ -60,7 +61,7 @@
       })
       $search.keydown(function(e) {
         switch (e.which) {
-          case keys.tab: e.preventDefault(); hide(); return;
+          case keys.tab: hide(); return;
           case keys.up: e.preventDefault(); listNavigator.prev(); return;
           case keys.down: e.preventDefault(); listNavigator.next(); return;
         }
@@ -69,12 +70,15 @@
       $list.on('click', 'li', function() { selectItem($(this).data('zelect-item')) })
       $zelect.mouseenter(function() { $zelect.addClass('hover') })
       $zelect.mouseleave(function() { $zelect.removeClass('hover') })
-      $zelect.attr("tabindex", $select.attr("tabindex"))
+      $search.attr("tabindex", $select.attr("tabindex"))
+      $focusCatcher.attr("tabindex", $select.attr("tabindex"))
       $zelect.blur(function() { if (!$zelect.hasClass('hover')) hide() })
       $search.blur(function() { if (!$zelect.hasClass('hover')) hide() })
 
       $selected.click(toggle)
+      $focusCatcher.focus(toggle)
 
+      $focusCatcher.insertBefore($select)
       $zelect.insertAfter($select)
         .append($selected)
         .append($dropdown.append($('<div>').addClass('zearch-container').append($search).append($noResults)).append($list))
@@ -115,6 +119,7 @@
 
       function toggle() {
         $dropdown.toggle()
+        $focusCatcher.hide()
         $zelect.toggleClass('open')
         if ($dropdown.is(':visible')) {
           $search.focus().select()
@@ -126,6 +131,7 @@
       function hide() {
         $dropdown.hide()
         $zelect.removeClass('open')
+        setTimeout(function(){ $focusCatcher.show() }, 0)
       }
 
       function renderContent($obj, content) {


### PR DESCRIPTION
I don't know if this can be tested further with PhantomJS+Mocha stack, but tabbing seems to work ok on Chrome and Firefox with these changes. You can try it with the included `tabtest.html`.

Relates to issue #17
